### PR TITLE
port 22 was mapped to 2222 and 22222

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,8 +21,6 @@ Vagrant.configure(2) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 80, host: 8888
-  config.vm.network "forwarded_port", guest: 22, host: 22222
-
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.


### PR DESCRIPTION
I had port 22 mapped to 2 ports, which was causing some problems. I think it's mapped to 2222 by default.  Please verify this works for you. 