### PR TITLE
remove software.zip from provisioning

### DIFF
--- a/roles/django_app/tasks/main.yml
+++ b/roles/django_app/tasks/main.yml
@@ -175,10 +175,3 @@
   notify: restart apache
   tags:
     - install
-
-- name: Copy software.zip for viewing result data
-  copy: src=software.zip dest={{ django_static }} owner=django group=django mode=0775
-  become: yes
-  become_method: sudo
-  tags:
-    - install


### PR DESCRIPTION
small pull request, but it will allow us to provision without usb-stick files