### PR TITLE
sparse checkout of svn introduced in run.sh of worker_python2.7

### DIFF
--- a/roles/worker_python2.7/templates/run.sh.j2
+++ b/roles/worker_python2.7/templates/run.sh.j2
@@ -2,7 +2,8 @@
 
 echo "Make checkout of subversion repository"
 cd /data
-svn checkout {{ repos_url }} --username=delft3dgt --password={{ svn_accp_pass }} --no-auth-cache svn
+svn checkout {{ repos_url }} --username=delft3dgt --password={{ svn_accp_pass }} --depth immediates --no-auth-cache svn
+svn update {{ repos_url }} --username=delft3dgt --password={{ svn_accp_pass }} --set-depth infinity --no-auth-cache svn/scripts svn/template
 echo "I'm updated"
 echo "start python script"
 for script in $@; do


### PR DESCRIPTION
svn checkout split in a checkout with depth immediates and an svn update with depth infinity on scripts and template directories