### PR TITLE
Restart celery to keep kubernetes python connection alive.

### DIFF
--- a/roles/celery/tasks/main.yml
+++ b/roles/celery/tasks/main.yml
@@ -60,7 +60,6 @@
         hour="0"
         user="root"
         job="systemctl restart celery.service"
-  when: "'aws-docker-manage' in group_names"
   tags:
     - configuration
     - worker


### PR DESCRIPTION
CentOS removes the temp connection file of kubernetes-python. Prevent this by restarting celery. For the underlying issue see https://github.com/kubernetes-client/python/issues/765
